### PR TITLE
Add missing dependency in samples.hxml

### DIFF
--- a/samples.hxml
+++ b/samples.hxml
@@ -1,5 +1,6 @@
 -cmd haxelib newrepo
 -cmd haxelib install msignal
+-cmd haxelib install pixijs 3.1.3
 
 --next
 


### PR DESCRIPTION
If you try to build samples right after checking out you end up with:
`Error: Error: Library pixijs is not installed : run 'haxelib install pixijs'`

Installing pixijs from samples.hxml to fix that.